### PR TITLE
falsy valued attrs should not be dropped

### DIFF
--- a/src/riemann/codec.clj
+++ b/src/riemann/codec.clj
@@ -72,7 +72,7 @@
                         (.setTime       event (long (:time e)))))
     (when (:ttl e)          (.setTtl          event (:ttl e)))
     (doseq [k (clojure.set/difference (set (keys e)) event-keys)]
-      (when-let [v (get e k)]
+      (when-some [v (get e k)]
         (let [a (Proto$Attribute/newBuilder)]
           (.setKey a (str (when (namespace k) (str (namespace k) \/)) (name k)))
           (.setValue a (str v))

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -119,7 +119,7 @@
     (is (= (msg {:events [expected]})
            (roundtrip {:events [original]})))))
 
-(deftest false-custom-attrbutes-should-not-be-removed-during-serialization
+(deftest false-custom-attributes
   (let [original {:host "host.1"
                   :service "service.1"
                   :nil-attr nil
@@ -128,4 +128,5 @@
                      (dissoc :nil-attr)
                      (assoc :false-attr "false"))]
     (is (= (msg {:events [expected]})
-           (roundtrip {:events [original]})))))
+           (roundtrip {:events [original]}))
+        "false values should be converted to string and not be removed")))

--- a/test/riemann/codec_test.clj
+++ b/test/riemann/codec_test.clj
@@ -118,3 +118,14 @@
         expected (dissoc original :empty-attr)]
     (is (= (msg {:events [expected]})
            (roundtrip {:events [original]})))))
+
+(deftest false-custom-attrbutes-should-not-be-removed-during-serialization
+  (let [original {:host "host.1"
+                  :service "service.1"
+                  :nil-attr nil
+                  :false-attr false}
+        expected (-> original
+                     (dissoc :nil-attr)
+                     (assoc :false-attr "false"))]
+    (is (= (msg {:events [expected]})
+           (roundtrip {:events [original]})))))


### PR DESCRIPTION
# Description

When encoding an event, if any of the custom attribute values are `false`, they are skipped from the event that is being sent to riemann. This patch fixes it by allowing all `non-nil` vals